### PR TITLE
[FEATURE] implement new feature "listfiles" (content of t3x files)

### DIFF
--- a/lib/etobi/extensionUtils/Controller/T3xController.php
+++ b/lib/etobi/extensionUtils/Controller/T3xController.php
@@ -74,6 +74,19 @@ class T3xController {
 	}
 
 	/**
+	 * @param string $t3xFilePath
+	 * @throws \Exception
+	 */
+	public function listFilesAction($t3xFilePath, $fullDetails = FALSE) {
+		if (!file_exists($t3xFilePath) || !is_file($t3xFilePath) || !is_readable($t3xFilePath)) {
+			throw new \Exception('Cant read "' . $t3xFilePath . '"');
+		}
+
+		$extensionData = $this->extractExtensionDataFromT3x($t3xFilePath);
+		$this->listFiles($extensionData['FILES'], $fullDetails);
+	}
+
+	/**
 	 * @param string $extKey
 	 * @param array $emConf
 	 * @param string $destinationPath
@@ -126,6 +139,22 @@ $EM_CONF[$_EXTKEY] = ' . var_export($emConf, TRUE) . ';
 				if (!$res) {
 					throw new \Exception('Cant write file "' . $fullFilePath . '"');
 				}
+			}
+		}
+	}
+
+	/**
+	 * @param array $files
+	 * @param boolean $fullDetails
+	 * @throws \Exception
+	 */
+	protected function listFiles($files, $fullDetails) {
+		if (!is_array($files)) return;
+		foreach ($files as $info) {
+			if ($fullDetails === TRUE) {
+				echo $info['content_md5'].' '.$info['size'].' '.utf8_decode($info['name']).PHP_EOL;
+			} else {
+				echo $info['name'].PHP_EOL;
 			}
 		}
 	}

--- a/lib/etobi/extensionUtils/Dispatcher.php
+++ b/lib/etobi/extensionUtils/Dispatcher.php
@@ -65,6 +65,9 @@ class Dispatcher {
 			case 'extract':
 				$success = $this->extractCommand($arguments);
 				break;
+			case 'listfiles':
+				$success = $this->listFilesCommand($arguments);
+				break;
 			case 'checkforupdate':
 				$success = $this->checkForUpdateCommand();
 				break;
@@ -100,6 +103,7 @@ class Dispatcher {
 			'fetch' => 'fetch <extensionKey> [<version>] [<destinationPath>]',
 			'upload' => 'upload <typo3.org-username> <typo3.org-password> <extensionKey> "<uploadComment>" <pathToExtension>',
 			'extract' => 'extract <t3x-file> <destinationPath>',
+			'listfiles' => 'listfiles <t3x-file> [details]',
 			'create' => 'create <extensionKey> <sourcePath> <t3x-file>',
 			'checkforupdate' => 'checkforupdate',
 			'selfupdate' => 'selfupdate'
@@ -212,6 +216,23 @@ class Dispatcher {
 		$success = $controller->extractAction(
 			$arguments[0],
 			$arguments[1]
+		);
+		return $success;
+	}
+
+	/**
+	 * @param array $arguments
+	 * @return bool
+	 */
+	protected function listFilesCommand($arguments) {
+		if (count($arguments) !== 1 && count($arguments) !== 2) {
+			return $this->helpCommand('listfiles');
+		}
+
+		$controller = new \etobi\extensionUtils\Controller\T3xController();
+		$success = $controller->listFilesAction(
+			$arguments[0],
+			isset($arguments[1]) ? TRUE : FALSE
 		);
 		return $success;
 	}


### PR DESCRIPTION
This feature enables users to list the content (files) of a t3x file, without extracting the files.
New command line argument introduced:

Usage: bin/t3xutils.php listfiles <t3x-file> [details]

By using the optional third argument "details", MD5 hashes and file sizes are included in the output. Without "details", only the list of files is shown.

The phar files has not been changed yet.
