### PR TITLE
[FEATURE] implement new feature "showmetadata"

### DIFF
--- a/lib/etobi/extensionUtils/Controller/T3xController.php
+++ b/lib/etobi/extensionUtils/Controller/T3xController.php
@@ -87,6 +87,19 @@ class T3xController {
 	}
 
 	/**
+	 * @param string $t3xFilePath
+	 * @throws \Exception
+	 */
+	public function showMetaDataAction($t3xFilePath) {
+		if (!file_exists($t3xFilePath) || !is_file($t3xFilePath) || !is_readable($t3xFilePath)) {
+			throw new \Exception('Cant read "' . $t3xFilePath . '"');
+		}
+
+		$extensionData = $this->extractExtensionDataFromT3x($t3xFilePath);
+		$this->showMetaData($extensionData['EM_CONF']);
+	}
+
+	/**
 	 * @param string $extKey
 	 * @param array $emConf
 	 * @param string $destinationPath
@@ -155,6 +168,19 @@ $EM_CONF[$_EXTKEY] = ' . var_export($emConf, TRUE) . ';
 				echo $info['content_md5'].' '.$info['size'].' '.utf8_decode($info['name']).PHP_EOL;
 			} else {
 				echo $info['name'].PHP_EOL;
+			}
+		}
+	}
+
+	/**
+	 * @param array $extensionData
+	 * @throws \Exception
+	 */
+	protected function showMetaData($extensionData) {
+		if (!is_array($extensionData)) return;
+		foreach ($extensionData as $keyword => $value) {
+			if(is_string($value) && !empty($value)) {
+				echo str_pad($keyword.':', 20, ' ', STR_PAD_RIGHT).' '.str_replace("\n", ' ', $value).PHP_EOL;
 			}
 		}
 	}

--- a/lib/etobi/extensionUtils/Dispatcher.php
+++ b/lib/etobi/extensionUtils/Dispatcher.php
@@ -68,6 +68,9 @@ class Dispatcher {
 			case 'listfiles':
 				$success = $this->listFilesCommand($arguments);
 				break;
+			case 'showmetadata':
+				$success = $this->showMetaDataCommand($arguments);
+				break;
 			case 'checkforupdate':
 				$success = $this->checkForUpdateCommand();
 				break;
@@ -104,6 +107,7 @@ class Dispatcher {
 			'upload' => 'upload <typo3.org-username> <typo3.org-password> <extensionKey> "<uploadComment>" <pathToExtension>',
 			'extract' => 'extract <t3x-file> <destinationPath>',
 			'listfiles' => 'listfiles <t3x-file> [details]',
+			'showmetadata' => 'showmetadata <t3x-file>',
 			'create' => 'create <extensionKey> <sourcePath> <t3x-file>',
 			'checkforupdate' => 'checkforupdate',
 			'selfupdate' => 'selfupdate'
@@ -233,6 +237,22 @@ class Dispatcher {
 		$success = $controller->listFilesAction(
 			$arguments[0],
 			isset($arguments[1]) ? TRUE : FALSE
+		);
+		return $success;
+	}
+
+	/**
+	 * @param array $arguments
+	 * @return bool
+	 */
+	protected function showMetaDataCommand($arguments) {
+		if (count($arguments) !== 1) {
+			return $this->helpCommand('showmetadata');
+		}
+
+		$controller = new \etobi\extensionUtils\Controller\T3xController();
+		$success = $controller->showMetaDataAction(
+			$arguments[0]
 		);
 		return $success;
 	}


### PR DESCRIPTION
This patch implements a new feature to show extension meta data such as extension title, state, author, email, etc. stored in a t3x file. The following example lists all extension details in file extensionkey_1.2.3.t3x:

php ./bin/t3xutils.php showmetadata /tmp/extensionkey_1.2.3.t3x
